### PR TITLE
Fixing build by specifying versions of each dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
-            <version>RELEASE</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava-math</artifactId>
-            <version>RELEASE</version>
+            <version>1.0.0</version>
         </dependency>
         <!--<dependency>-->
         <!--<groupId>com.netflix.rxjava</groupId>-->
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>RELEASE</version>
+            <version>4.12</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/vgrazi/play/GeneralCodeSamples.java
+++ b/src/main/java/com/vgrazi/play/GeneralCodeSamples.java
@@ -1,8 +1,19 @@
 package com.vgrazi.play;
 
 import org.junit.Test;
-import rx.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import rx.Completable;
 import rx.Observable;
+import rx.Scheduler;
+import rx.Single;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.observables.ConnectableObservable;
@@ -10,10 +21,6 @@ import rx.observables.MathObservable;
 import rx.schedulers.Schedulers;
 import rx.subjects.AsyncSubject;
 import rx.subjects.Subject;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
 
 public class GeneralCodeSamples {
 
@@ -656,7 +663,7 @@ public class GeneralCodeSamples {
 
   @Test
   public void testCompletable() {
-    Completable.create((Completable.CompletableOnSubscribe) s -> System.out.println(s));
+    Completable.create(s -> System.out.println(s));
   }
 
   private static void sleep(long value) {


### PR DESCRIPTION
I checked out this project after reading an article on InfoQ. However, locally on my PC, the build was failing with the following compilation error:

[ERROR] /home/maria/dev/rxjava-snippets-fork/src/main/java/com/vgrazi/play/GeneralCodeSamples.java:[659,36] cannot find symbol
  symbol:   class CompletableOnSubscribe
  location: class rx.Completable

Since the metaversion RELEASE was being used, the build was not reproducible, as it was subject to changes in the projects being depended on. I therefore opened this pull request to set your dependency versions to more specific versions. In maven 3, RELEASE has actually been deprecated, as you can read [here](https://cwiki.apache.org/confluence/display/MAVEN/Maven+3.x+Compatibility+Notes#Maven3.xCompatibilityNotes-PluginMetaversionResolution)
